### PR TITLE
Active model serializers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,5 @@ gem "bcrypt", "~> 3.1"
 gem "annotate", "~> 3.2"
 
 gem "jwt", "~> 2.9"
+
+gem "active_model_serializers", "~> 0.10.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.14)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.1.7.8)
       activesupport (= 6.1.7.8)
       globalid (>= 0.3.6)
@@ -70,6 +75,8 @@ GEM
       msgpack (~> 1.2)
     builder (3.3.0)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.3.4)
     crass (1.0.6)
     date (3.3.4)
@@ -82,6 +89,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jsonapi-renderer (0.2.2)
     jwt (2.9.0)
       base64
     listen (3.9.0)
@@ -203,6 +211,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.14)
   annotate (~> 3.2)
   bcrypt (~> 3.1)
   bootsnap (>= 1.4.4)

--- a/app/serializers/account_block/account_serializer.rb
+++ b/app/serializers/account_block/account_serializer.rb
@@ -1,0 +1,3 @@
+class AccountBlock::AccountSerializer < ActiveModel::Serializer
+  attributes :id, :email, :first_name, :last_name
+end

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json_api


### PR DESCRIPTION
- Add `active_model_serializer` gem
- Serialize the `account` model with custom attributes using `json_api` as a config adapter.